### PR TITLE
docs: READMEとアーキテクチャ図を現在の構成に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,103 @@
 # early_riser
 
-### ALBのDNS（フロントエンド側でfetchするときに使用する）
-```
-early-riser-alb-771564224.ap-northeast-1.elb.amazonaws.com
+プレスリリースエディターアプリケーション
+
+## URL
+
+| 環境 | URL |
+|------|-----|
+| フロントエンド (S3) | http://early-riser-frontend-726725835302.s3-website-ap-northeast-1.amazonaws.com |
+| バックエンド API (ALB) | http://early-riser-alb-771564224.ap-northeast-1.elb.amazonaws.com |
+
+## API エンドポイント
+
+| メソッド | パス | 説明 |
+|----------|------|------|
+| GET | `/api/press-releases/{id}` | プレスリリース取得 |
+| POST | `/api/press-releases/{id}` | プレスリリース保存 |
+| POST | `/api/upload` | 画像アップロード |
+| GET | `/` | ヘルスチェック |
+
+### フロントエンドからの fetch 例
+
+```typescript
+// プレスリリース取得
+const res = await fetch("http://early-riser-alb-771564224.ap-northeast-1.elb.amazonaws.com/api/press-releases/1");
+const data = await res.json();
+
+// プレスリリース保存
+await fetch("http://early-riser-alb-771564224.ap-northeast-1.elb.amazonaws.com/api/press-releases/1", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ title: "タイトル", content: "コンテンツJSON" }),
+});
 ```
 
+## アーキテクチャ
 
+```
+┌─────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Users  │────▶│  S3 (Frontend)   │     │  GitHub Actions  │
+│         │     │  Next.js Static  │     │                  │
+└─────────┘     └──────────────────┘     └────────┬─────────┘
+     │                                        │         │
+     │ API                              ECR Push   S3 Sync
+     │                                        │         │
+     ▼                                        ▼         ▼
+┌──────────┐     ┌──────────────────┐     ┌──────────────────┐
+│   ALB    │────▶│  ECS Fargate     │     │  ECR             │
+│  :80     │     │  PHP/Slim :8080  │     │  Docker Images   │
+└──────────┘     └────────┬─────────┘     └──────────────────┘
+                          │
+                 ┌────────┼─────────┐
+                 ▼                  ▼
+        ┌──────────────┐   ┌──────────────┐
+        │  RDS         │   │  S3 (Images) │
+        │  PostgreSQL  │   │              │
+        └──────────────┘   └──────────────┘
+```
+
+詳細な構成図: [architecture/AWS.drawio](architecture/AWS.drawio)
+
+## 技術スタック
+
+| レイヤー | 技術 |
+|----------|------|
+| フロントエンド | Next.js 16 (Static Export) / React / TipTap Editor |
+| バックエンド | PHP 8.5 / Slim Framework 4 |
+| データベース | PostgreSQL 16 (RDS) |
+| インフラ | AWS (ECS Fargate, ALB, S3, RDS, ECR) |
+| CI/CD | GitHub Actions (OIDC認証) |
+
+## CI/CD
+
+PRを main にマージすると自動デプロイが実行されます。
+
+| ワークフロー | トリガー | デプロイ先 |
+|-------------|----------|-----------|
+| `deploy-backend.yml` | `webapp/php/**` の変更 | ECR → ECS Fargate |
+| `deploy-frontend.yml` | `webapp/nextjs/**` の変更 | S3 Static Hosting |
+
+## ローカル開発
+
+```bash
+# バックエンド
+cd webapp/php
+composer install
+php -S localhost:8080 -t public
+
+# フロントエンド
+cd webapp/nextjs
+npm install
+npm run dev
+```
+
+## 環境変数
+
+フロントエンド（ビルド時）:
+- `NEXT_PUBLIC_API_URL` - バックエンド API の URL
+
+バックエンド（ECS タスク定義 / GitHub Secrets & Variables）:
+- `DB_HOST` / `DB_PORT` / `DB_DATABASE` / `DB_USERNAME` / `DB_PASSWORD`
+- `APP_ENV` / `APP_KEY`
+- `AWS_BUCKET_IMAGES` / `AWS_BUCKET_IMAGES_URL`

--- a/architecture/AWS.drawio
+++ b/architecture/AWS.drawio
@@ -1,0 +1,119 @@
+<mxfile host="65bd71144e">
+    <diagram name="early_riser AWS Architecture" id="early-riser-arch">
+        <mxGraphModel dx="1800" dy="1200" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1920" pageHeight="1080" background="#ffffff" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <!-- Users -->
+                <mxCell id="users" value="&lt;font style=&quot;font-size: 18px;&quot;&gt;Users&lt;/font&gt;" style="sketch=0;outlineConnect=0;gradientColor=none;fontColor=#545B64;strokeColor=none;fillColor=#879196;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.illustration_users;pointerEvents=1" parent="1" vertex="1">
+                    <mxGeometry x="40" y="400" width="80" height="80" as="geometry"/>
+                </mxCell>
+                <!-- GitHub -->
+                <mxCell id="github" value="&lt;font style=&quot;font-size: 16px;&quot;&gt;GitHub&lt;br&gt;Actions&lt;/font&gt;" style="verticalLabelPosition=bottom;html=1;verticalAlign=top;align=center;strokeColor=none;fillColor=#00BEF2;shape=mxgraph.azure.github_code;pointerEvents=1;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="80" width="80" height="76" as="geometry"/>
+                </mxCell>
+                <!-- AWS Cloud -->
+                <mxCell id="aws_cloud" value="&lt;font style=&quot;font-size: 18px;&quot;&gt;AWS Cloud (ap-northeast-1)&lt;/font&gt;" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;" parent="1" vertex="1">
+                    <mxGeometry x="200" y="20" width="1500" height="1000" as="geometry"/>
+                </mxCell>
+                <!-- VPC -->
+                <mxCell id="vpc" value="&lt;font style=&quot;font-size: 16px;&quot;&gt;VPC (10.0.0.0/16)&lt;/font&gt;" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_vpc2;strokeColor=#8C4FFF;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#AAB7B8;dashed=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="220" y="200" width="1050" height="700" as="geometry"/>
+                </mxCell>
+                <!-- Public Subnet -->
+                <mxCell id="pub_sub" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;Public Subnet (ap-northeast-1a, 1c)&lt;/font&gt;" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_security_group;grStroke=0;strokeColor=#7AA116;fillColor=#F2F6E8;verticalAlign=top;align=left;spacingLeft=30;fontColor=#248814;dashed=0;" parent="vpc" vertex="1">
+                    <mxGeometry x="30" y="50" width="990" height="620" as="geometry"/>
+                </mxCell>
+                <!-- ALB -->
+                <mxCell id="alb_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.elastic_load_balancing;" parent="pub_sub" vertex="1">
+                    <mxGeometry x="80" y="180" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="alb_label" value="&lt;font style=&quot;font-size: 16px;&quot; color=&quot;#000000&quot;&gt;ALB (:80)&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="pub_sub" vertex="1">
+                    <mxGeometry x="40" y="250" width="140" height="30" as="geometry"/>
+                </mxCell>
+                <!-- ECS Fargate -->
+                <mxCell id="ecs_group" value="ECS Fargate (0.25 vCPU / 512MB)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_spot_fleet;strokeColor=#D86613;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#D86613;dashed=0;" parent="pub_sub" vertex="1">
+                    <mxGeometry x="280" y="100" width="260" height="220" as="geometry"/>
+                </mxCell>
+                <mxCell id="fargate_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.fargate;" parent="ecs_group" vertex="1">
+                    <mxGeometry x="90" y="50" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="fargate_label" value="&lt;font style=&quot;font-size: 14px;&quot; color=&quot;#000000&quot;&gt;PHP/Slim (:8080)&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="ecs_group" vertex="1">
+                    <mxGeometry x="40" y="120" width="170" height="40" as="geometry"/>
+                </mxCell>
+                <!-- RDS -->
+                <mxCell id="rds_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.rds;" parent="pub_sub" vertex="1">
+                    <mxGeometry x="710" y="180" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="rds_label" value="&lt;font style=&quot;font-size: 14px;&quot; color=&quot;#000000&quot;&gt;RDS PostgreSQL 16&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="pub_sub" vertex="1">
+                    <mxGeometry x="650" y="250" width="180" height="30" as="geometry"/>
+                </mxCell>
+                <!-- S3 Frontend -->
+                <mxCell id="s3fe_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="50" y="500" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3fe_label" value="&lt;font style=&quot;font-size: 14px;&quot; color=&quot;#000000&quot;&gt;S3 (Frontend)&lt;br&gt;Next.js Static&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="10" y="570" width="140" height="40" as="geometry"/>
+                </mxCell>
+                <!-- S3 Images -->
+                <mxCell id="s3img_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="50" y="700" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3img_label" value="&lt;font style=&quot;font-size: 14px;&quot; color=&quot;#000000&quot;&gt;S3 (Images)&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="20" y="770" width="120" height="30" as="geometry"/>
+                </mxCell>
+                <!-- ECR -->
+                <mxCell id="ecr_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecr;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="380" y="60" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="ecr_label" value="&lt;font style=&quot;font-size: 14px;&quot; color=&quot;#000000&quot;&gt;ECR&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="370" y="130" width="80" height="30" as="geometry"/>
+                </mxCell>
+                <!-- CloudWatch -->
+                <mxCell id="cw_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="700" y="60" width="60" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="cw_label" value="&lt;font style=&quot;font-size: 14px;&quot; color=&quot;#000000&quot;&gt;CloudWatch Logs&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="650" y="130" width="160" height="30" as="geometry"/>
+                </mxCell>
+                <!-- Edges -->
+                <!-- Users -> S3 Frontend -->
+                <mxCell id="e1" value="HTTP" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#545B64;rounded=0;fontSize=11;fontColor=#545B64;" parent="1" source="users" target="s3fe_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Users -> ALB -->
+                <mxCell id="e2" value="API" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#545B64;rounded=0;fontSize=11;fontColor=#545B64;" parent="1" source="users" target="alb_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- ALB -> Fargate -->
+                <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="alb_icon" target="fargate_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Fargate -> RDS -->
+                <mxCell id="e4" value="PostgreSQL" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#545B64;rounded=0;fontSize=11;fontColor=#545B64;" parent="1" source="fargate_icon" target="rds_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Fargate -> S3 Images -->
+                <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="fargate_icon" target="s3img_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- Fargate -> CloudWatch -->
+                <mxCell id="e6" value="Logs" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;fontSize=11;fontColor=#545B64;" parent="1" source="fargate_icon" target="cw_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- GitHub -> ECR -->
+                <mxCell id="e7" value="Docker Push" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#2E73B8;rounded=0;fontSize=11;fontColor=#2E73B8;" parent="1" source="github" target="ecr_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- ECR -> ECS -->
+                <mxCell id="e8" value="Deploy" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#2E73B8;rounded=0;dashed=1;fontSize=11;fontColor=#2E73B8;" parent="1" source="ecr_icon" target="fargate_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <!-- GitHub -> S3 Frontend -->
+                <mxCell id="e9" value="S3 Sync" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;endFill=1;strokeColor=#2E73B8;rounded=0;fontSize=11;fontColor=#2E73B8;" parent="1" source="github" target="s3fe_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- README に URL一覧、APIエンドポイント、fetchの使用例、技術スタック、CI/CD情報を記載
- AWS.drawio を実際の構成に合わせて再作成
  - 使用中: S3 (Frontend/Images), ALB, ECS Fargate (PHP/Slim), RDS PostgreSQL, ECR, CloudWatch
  - 削除: WAF, CloudFront, Cognito, Bedrock, SQS, DynamoDB, X-Ray, SNS (未使用)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with comprehensive application overview, API endpoints, usage examples, tech stack, CI/CD information, and local development setup instructions.
  * Added AWS architecture diagram illustrating system design and service interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->