### PR TITLE
S3プリサインURLによる画像アップロード機能 #40

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -70,7 +70,8 @@ jobs:
             {"name": "DB_USERNAME", "value": "${{ secrets.DB_USERNAME }}"},
             {"name": "DB_PASSWORD", "value": "${{ secrets.DB_PASSWORD }}"},
             {"name": "AWS_BUCKET_IMAGES", "value": "${{ vars.AWS_BUCKET_IMAGES }}"},
-            {"name": "AWS_BUCKET_IMAGES_URL", "value": "${{ vars.AWS_BUCKET_IMAGES_URL }}"}
+            {"name": "AWS_BUCKET_IMAGES_URL", "value": "${{ vars.AWS_BUCKET_IMAGES_URL }}"},
+            {"name": "AWS_REGION", "value": "ap-northeast-1"}
           ]' task-definition.json > task-definition-updated.json
           mv task-definition-updated.json task-definition.json
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 |----------|------|------|
 | GET | `/api/press-releases/{id}` | プレスリリース取得 |
 | POST | `/api/press-releases/{id}` | プレスリリース保存 |
-| POST | `/api/upload` | 画像アップロード |
+| POST | `/api/images/presigned-url` | 画像アップロード用プリサインURL取得 |
 | GET | `/` | ヘルスチェック |
 
 ### フロントエンドからの fetch 例
@@ -31,6 +31,27 @@ await fetch("http://early-riser-alb-771564224.ap-northeast-1.elb.amazonaws.com/a
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({ title: "タイトル", content: "コンテンツJSON" }),
 });
+```
+
+### 画像アップロード（S3プリサインURL）
+
+```typescript
+// 1. プリサインURLを取得
+const res = await fetch("http://early-riser-alb-771564224.ap-northeast-1.elb.amazonaws.com/api/images/presigned-url", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ contentType: "image/png", fileName: "photo.png" }),
+});
+const { uploadUrl, imageUrl } = await res.json();
+
+// 2. S3に直接アップロード
+await fetch(uploadUrl, {
+  method: "PUT",
+  headers: { "Content-Type": "image/png" },
+  body: file, // Fileオブジェクト
+});
+
+// 3. imageUrl をエディタに挿入
 ```
 
 ## アーキテクチャ

--- a/webapp/nextjs/app/editor/_components/ToolBar/Toolbar.tsx
+++ b/webapp/nextjs/app/editor/_components/ToolBar/Toolbar.tsx
@@ -2,10 +2,8 @@
 
 import { useRef } from 'react';
 import type { Editor } from '@tiptap/react';
+import { getPresignedUrl, uploadToS3 } from '@/lib/imageUpload';
 import styles from './Toolbar.module.css';
-
-// TODO: PHP APIに置き換える際はこのURLを変更する
-const UPLOAD_API_URL = '/api/upload';
 
 interface ToolbarProps {
   editor: Editor | null;
@@ -20,18 +18,10 @@ export default function Toolbar({ editor }: ToolbarProps) {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const formData = new FormData();
-    formData.append('file', file);
-
     try {
-      const res = await fetch(UPLOAD_API_URL, { method: 'POST', body: formData });
-      if (!res.ok) {
-        const data = await res.json();
-        alert(data.error || '画像のアップロードに失敗しました');
-        return;
-      }
-      const { url } = await res.json();
-      editor.chain().focus().setImage({ src: url }).run();
+      const { uploadUrl, imageUrl } = await getPresignedUrl(file.type, file.name);
+      await uploadToS3(uploadUrl, file);
+      editor.chain().focus().setImage({ src: imageUrl }).run();
     } catch {
       alert('画像のアップロードに失敗しました');
     } finally {

--- a/webapp/nextjs/app/editor/page.tsx
+++ b/webapp/nextjs/app/editor/page.tsx
@@ -17,6 +17,7 @@ import Bold from '@tiptap/extension-bold';
 import Italic from '@tiptap/extension-italic';
 import ImageNodeView from './_components/ImageNodeView';
 import Toolbar from './_components/ToolBar/Toolbar';
+import { getPresignedUrl, uploadToS3 } from '@/lib/imageUpload';
 import type { PressRelease } from '@/lib/types';
 import styles from './page.module.css';
 
@@ -90,7 +91,6 @@ interface EditorProps {
   initialContent: string;
 }
 
-const UPLOAD_API_URL = `${API_URL}/api/upload`;
 
 function Editor({ initialTitle, initialContent }: EditorProps) {
   const [title, setTitle] = useState(initialTitle);
@@ -135,22 +135,14 @@ function Editor({ initialTitle, initialContent }: EditorProps) {
             const coordinates = view.posAtCoords({ left: event.clientX, top: event.clientY });
             if (!coordinates) return false;
 
-            // 非同期でAPIに画像をアップロードする関数
+            // 非同期でプリサインURLを取得しS3に直接アップロード
             const uploadDroppedImage = async () => {
-              const formData = new FormData();
-              formData.append('file', file);
-
               try {
-                const res = await fetch(UPLOAD_API_URL, { method: 'POST', body: formData });
-                if (!res.ok) {
-                  const data = await res.json();
-                  alert(data.error || '画像のアップロードに失敗しました');
-                  return;
-                }
-                const { url } = await res.json();
+                const { uploadUrl, imageUrl } = await getPresignedUrl(file.type, file.name);
+                await uploadToS3(uploadUrl, file);
 
                 // アップロードが完了したら、ドロップした位置に画像を挿入
-                const node = view.state.schema.nodes.image.create({ src: url });
+                const node = view.state.schema.nodes.image.create({ src: imageUrl });
                 const transaction = view.state.tr.insert(coordinates.pos, node);
                 view.dispatch(transaction);
               } catch {

--- a/webapp/nextjs/lib/imageUpload.ts
+++ b/webapp/nextjs/lib/imageUpload.ts
@@ -1,0 +1,33 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+interface PresignedUrlResponse {
+  uploadUrl: string;
+  imageUrl: string;
+}
+
+export async function getPresignedUrl(contentType: string, fileName: string): Promise<PresignedUrlResponse> {
+  const res = await fetch(`${API_URL}/api/images/presigned-url`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contentType, fileName }),
+  });
+
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.error || 'プリサインURLの取得に失敗しました');
+  }
+
+  return res.json();
+}
+
+export async function uploadToS3(uploadUrl: string, file: File): Promise<void> {
+  const res = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': file.type },
+    body: file,
+  });
+
+  if (!res.ok) {
+    throw new Error('S3へのアップロードに失敗しました');
+  }
+}

--- a/webapp/php/composer.json
+++ b/webapp/php/composer.json
@@ -8,7 +8,8 @@
     "slim/psr7": "^1.7",
     "ext-json": "*",
     "ext-pdo": "*",
-    "ext-ctype": "*"
+    "ext-ctype": "*",
+    "aws/aws-sdk-php": "^3.300"
   },
   "autoload": {
     "psr-4": {

--- a/webapp/php/public/index.php
+++ b/webapp/php/public/index.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use App\GetPressReleaseController;
 use App\SavePressReleaseController;
+use App\ImageUploadController;
 use Slim\Factory\AppFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,6 +36,8 @@ $app->get('/api/press-releases/{id}', GetPressReleaseController::class . '::hand
 $app->post('/api/press-releases/{id}', SavePressReleaseController::class . '::handle');
 $app->get('/press-releases/{id}', GetPressReleaseController::class . '::handle');
 $app->post('/press-releases/{id}', SavePressReleaseController::class . '::handle');
+
+$app->post('/api/images/presigned-url', ImageUploadController::class . '::handle');
 
 $app->addRoutingMiddleware();
 $app->addErrorMiddleware(true, true, true);

--- a/webapp/php/src/ImageUploadController.php
+++ b/webapp/php/src/ImageUploadController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App;
+
+use Aws\S3\S3Client;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ImageUploadController
+{
+    private const ALLOWED_CONTENT_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+    ];
+
+    private const PRESIGNED_URL_EXPIRY = '+10 minutes';
+
+    public static function handle(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $body = json_decode((string)$request->getBody(), true);
+        $contentType = $body['contentType'] ?? '';
+        $fileName = $body['fileName'] ?? '';
+
+        if (!in_array($contentType, self::ALLOWED_CONTENT_TYPES, true)) {
+            $response->getBody()->write(json_encode([
+                'error' => '許可されていないファイル形式です。JPEG, PNG, GIF, WebPのみアップロードできます。',
+            ]));
+            return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
+        }
+
+        $bucket = getenv('AWS_BUCKET_IMAGES') ?: '';
+        $bucketUrl = getenv('AWS_BUCKET_IMAGES_URL') ?: '';
+        $region = getenv('AWS_REGION') ?: 'ap-northeast-1';
+
+        $extension = match ($contentType) {
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            default => 'bin',
+        };
+
+        $key = 'images/' . uniqid('img_', true) . '.' . $extension;
+
+        $s3 = new S3Client([
+            'region' => $region,
+            'version' => 'latest',
+        ]);
+
+        $cmd = $s3->getCommand('PutObject', [
+            'Bucket' => $bucket,
+            'Key' => $key,
+            'ContentType' => $contentType,
+        ]);
+
+        $presignedRequest = $s3->createPresignedRequest($cmd, self::PRESIGNED_URL_EXPIRY);
+        $uploadUrl = (string)$presignedRequest->getUri();
+
+        $imageUrl = rtrim($bucketUrl, '/') . '/' . $key;
+
+        $response->getBody()->write(json_encode([
+            'uploadUrl' => $uploadUrl,
+            'imageUrl' => $imageUrl,
+        ]));
+
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+}


### PR DESCRIPTION
## Summary
- PHP Backend: `aws/aws-sdk-php` 導入、`POST /api/images/presigned-url` エンドポイント追加
- Frontend: ツールバーの画像追加・ドラッグ&ドロップをプリサインURLフローに変更
- 共通 `lib/imageUpload.ts` モジュールを作成し、Toolbar.tsx と page.tsx で再利用

## Test plan
- [ ] バックエンドデプロイ後、`POST /api/images/presigned-url` が `{uploadUrl, imageUrl}` を返すことを確認
- [ ] ツールバーの「画像追加」ボタンで画像がS3にアップロード・エディタに挿入されることを確認
- [ ] ドラッグ&ドロップで画像がS3にアップロード・エディタに挿入されることを確認

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented client-side image uploads directly to S3 using presigned URLs, eliminating server-side upload processing.

* **Documentation**
  * Updated API documentation to reflect the new presigned URL endpoint and image upload workflow.

* **Chores**
  * Added AWS SDK dependency and updated deployment configuration with required AWS region settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->