### PR TITLE
HTMLインポート機能の追加 #45

### DIFF
--- a/webapp/nextjs/app/editor/_components/HtmlImportModal/HtmlImportModal.module.css
+++ b/webapp/nextjs/app/editor/_components/HtmlImportModal/HtmlImportModal.module.css
@@ -1,0 +1,129 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: white;
+  border-radius: 8px;
+  width: 700px;
+  max-width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 1.5rem;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: #666;
+  padding: 0.25rem;
+}
+
+.closeButton:hover {
+  color: #333;
+}
+
+.textarea {
+  width: 100%;
+  font-family: monospace;
+  font-size: 0.875rem;
+  padding: 0.75rem;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: #0056b3;
+}
+
+.preview {
+  margin-top: 1rem;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  padding: 0.75rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.previewLabel {
+  font-size: 0.75rem;
+  color: #888;
+  margin: 0 0 0.5rem 0;
+}
+
+.previewContent {
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.previewContent img {
+  max-width: 100%;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.cancelButton {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cancelButton:hover {
+  background: #e9ecef;
+}
+
+.importButton {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: #0056b3;
+  color: white;
+  border: 1px solid #0056b3;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.importButton:hover {
+  background: #004094;
+}
+
+.importButton:disabled {
+  background: #6c9bd2;
+  border-color: #6c9bd2;
+  cursor: not-allowed;
+}

--- a/webapp/nextjs/app/editor/_components/HtmlImportModal/HtmlImportModal.tsx
+++ b/webapp/nextjs/app/editor/_components/HtmlImportModal/HtmlImportModal.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './HtmlImportModal.module.css';
+
+interface HtmlImportModalProps {
+  onImport: (html: string) => void;
+  onClose: () => void;
+}
+
+export default function HtmlImportModal({ onImport, onClose }: HtmlImportModalProps) {
+  const [html, setHtml] = useState('');
+
+  const handleImport = () => {
+    if (!html.trim()) return;
+    onImport(html);
+    onClose();
+  };
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>HTMLインポート</h2>
+          <button onClick={onClose} className={styles.closeButton}>✕</button>
+        </div>
+        <textarea
+          className={styles.textarea}
+          value={html}
+          onChange={(e) => setHtml(e.target.value)}
+          placeholder="HTMLを貼り付けてください"
+          rows={15}
+        />
+        <div className={styles.preview}>
+          <p className={styles.previewLabel}>プレビュー</p>
+          <div
+            className={styles.previewContent}
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
+        <div className={styles.actions}>
+          <button onClick={onClose} className={styles.cancelButton}>キャンセル</button>
+          <button onClick={handleImport} className={styles.importButton} disabled={!html.trim()}>
+            インポート
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webapp/nextjs/app/editor/_components/ToolBar/Toolbar.tsx
+++ b/webapp/nextjs/app/editor/_components/ToolBar/Toolbar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import type { Editor } from '@tiptap/react';
 import { getPresignedUrl, uploadToS3 } from '@/lib/imageUpload';
+import HtmlImportModal from '../HtmlImportModal/HtmlImportModal';
 import styles from './Toolbar.module.css';
 
 interface ToolbarProps {
@@ -11,6 +12,7 @@ interface ToolbarProps {
 
 export default function Toolbar({ editor }: ToolbarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showHtmlImport, setShowHtmlImport] = useState(false);
 
   if (!editor) return null;
 
@@ -60,39 +62,54 @@ export default function Toolbar({ editor }: ToolbarProps) {
     }
   };
 
+  const handleHtmlImport = (html: string) => {
+    editor.chain().focus().setContent(html).run();
+  };
+
   const buttonClass = (name: string) =>
     `${styles.toolbarButton} ${editor.isActive(name) ? styles.toolbarButtonActive : ''}`;
 
   return (
-    <div className={styles.toolbar}>
-      <button onClick={handleBold} className={buttonClass('bold')}>
-        <strong>B</strong>
-      </button>
-      <button onClick={handleItalic} className={buttonClass('italic')}>
-        <em>I</em>
-      </button>
-      <button onClick={handleUnderline} className={buttonClass('underline')}>
-        <u>U</u>
-      </button>
-      <button onClick={handleBulletList} className={buttonClass('bulletList')}>
-        箇条書き
-      </button>
-      <button onClick={handleOrderedList} className={buttonClass('orderedList')}>
-        番号付きリスト
-      </button>
-      <button onClick={handleImageClick} className={styles.toolbarButton}>
-        画像追加
-      </button>
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/jpeg,image/png,image/gif,image/webp"
-        onChange={handleImageUpload}
-        hidden
-      />
-      <button onClick={handleLink} className={buttonClass('link')}>
-        🔗
-      </button>
-    </div>
+    <>
+      <div className={styles.toolbar}>
+        <button onClick={handleBold} className={buttonClass('bold')}>
+          <strong>B</strong>
+        </button>
+        <button onClick={handleItalic} className={buttonClass('italic')}>
+          <em>I</em>
+        </button>
+        <button onClick={handleUnderline} className={buttonClass('underline')}>
+          <u>U</u>
+        </button>
+        <button onClick={handleBulletList} className={buttonClass('bulletList')}>
+          箇条書き
+        </button>
+        <button onClick={handleOrderedList} className={buttonClass('orderedList')}>
+          番号付きリスト
+        </button>
+        <button onClick={handleImageClick} className={styles.toolbarButton}>
+          画像追加
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp"
+          onChange={handleImageUpload}
+          hidden
+        />
+        <button onClick={handleLink} className={buttonClass('link')}>
+          🔗
+        </button>
+        <button onClick={() => setShowHtmlImport(true)} className={styles.toolbarButton}>
+          HTMLインポート
+        </button>
+      </div>
+      {showHtmlImport && (
+        <HtmlImportModal
+          onImport={handleHtmlImport}
+          onClose={() => setShowHtmlImport(false)}
+        />
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- ツールバーに「HTMLインポート」ボタンを追加
- モーダルでHTMLを貼り付け、リアルタイムプレビュー確認後にエディタへインポート
- HtmlImportModalコンポーネントを新規作成

## Test plan
- [ ] 「HTMLインポート」ボタンでモーダルが開くことを確認
- [ ] HTMLを貼り付けるとプレビューが表示されることを確認
- [ ] 「インポート」ボタンでエディタにHTMLが反映されることを確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTML import modal with live preview functionality
  * New toolbar button to access the HTML import feature
  * Built-in validation ensures only non-empty HTML can be imported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->