### PR TITLE
fix: gpt-5.4モデル用にAPIタイムアウトを延長

### DIFF
--- a/webapp/php/src/Service/AiGenerateService.php
+++ b/webapp/php/src/Service/AiGenerateService.php
@@ -135,7 +135,7 @@ PROMPT;
                 'Content-Type: application/json',
                 'Authorization: Bearer ' . $apiKey,
             ],
-            CURLOPT_TIMEOUT => 60,
+            CURLOPT_TIMEOUT => 120,
         ]);
 
         $result = curl_exec($ch);

--- a/webapp/php/src/Service/ToneAnalysisService.php
+++ b/webapp/php/src/Service/ToneAnalysisService.php
@@ -147,7 +147,7 @@ PROMPT;
                 'Content-Type: application/json',
                 'Authorization: Bearer ' . $apiKey,
             ],
-            CURLOPT_TIMEOUT => 45,
+            CURLOPT_TIMEOUT => 120,
         ]);
 
         $result = curl_exec($ch);


### PR DESCRIPTION
## Summary
- AiGenerateService: タイムアウト 60秒 -> 120秒
- ToneAnalysisService: タイムアウト 45秒 -> 120秒

gpt-5.4は処理時間が長いため、タイムアウトを延長して502エラーを解消

## Test plan
- [ ] AIテンプレート生成が502にならないか確認
- [ ] トーン分析が502にならないか確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI generation and tone analysis features by extending timeout limits, preventing premature request cancellations during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->