### PR TITLE
fix: AI APIとALBのタイムアウトを300秒に延長

### DIFF
--- a/webapp/php/src/Service/AiGenerateService.php
+++ b/webapp/php/src/Service/AiGenerateService.php
@@ -135,7 +135,7 @@ PROMPT;
                 'Content-Type: application/json',
                 'Authorization: Bearer ' . $apiKey,
             ],
-            CURLOPT_TIMEOUT => 120,
+            CURLOPT_TIMEOUT => 300,
         ]);
 
         $result = curl_exec($ch);

--- a/webapp/php/src/Service/ToneAnalysisService.php
+++ b/webapp/php/src/Service/ToneAnalysisService.php
@@ -147,7 +147,7 @@ PROMPT;
                 'Content-Type: application/json',
                 'Authorization: Bearer ' . $apiKey,
             ],
-            CURLOPT_TIMEOUT => 120,
+            CURLOPT_TIMEOUT => 300,
         ]);
 
         $result = curl_exec($ch);


### PR DESCRIPTION
## Summary
- AiGenerateService / ToneAnalysisService: curlタイムアウト 120秒 -> 300秒
- ALB idle_timeout: 60秒 -> 300秒（AWS CLIで設定済み）

504エラーはALBのタイムアウト(60秒)が原因。gpt-5.4の応答時間に対応。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased API timeout duration for AI-powered features including content generation and tone analysis capabilities. This infrastructure enhancement allows longer-running operations to complete successfully without experiencing premature timeout errors, significantly improving overall reliability and user experience when processing complex requests, larger datasets, or resource-intensive AI-powered tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->