### PR TITLE
fix: OpenAIモデルをgpt-4o-miniに戻す

### DIFF
--- a/webapp/php/src/Service/AiGenerateService.php
+++ b/webapp/php/src/Service/AiGenerateService.php
@@ -115,7 +115,7 @@ PROMPT;
     private static function callOpenAI(string $apiKey, string $systemPrompt, string $userPrompt): string
     {
         $payload = json_encode([
-            'model' => 'gpt-5.4',
+            'model' => 'gpt-4o-mini',
             'messages' => [
                 ['role' => 'system', 'content' => $systemPrompt],
                 ['role' => 'user', 'content' => $userPrompt],

--- a/webapp/php/src/Service/ToneAnalysisService.php
+++ b/webapp/php/src/Service/ToneAnalysisService.php
@@ -126,7 +126,7 @@ PROMPT;
     private static function callOpenAI(string $apiKey, string $prompt): string
     {
         $payload = json_encode([
-            'model' => 'gpt-5.4',
+            'model' => 'gpt-4o-mini',
             'messages' => [
                 ['role' => 'system', 'content' => 'あなたはプレスリリースの文章品質分析の専門家です。指定されたJSON形式のみで回答してください。'],
                 ['role' => 'user', 'content' => $prompt],


### PR DESCRIPTION
gpt-5.4のタイムアウト問題により、安定動作するgpt-4o-miniに戻す